### PR TITLE
Add support to the Faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 # gem "rails"
 
+gem 'faraday', '~> 2.9'
+
 gem 'rspec', '~> 3.12', group: :test
 
 gem 'rubocop', '~> 1.56', groups: %i[development test], require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,8 +5,14 @@ GEM
     base64 (0.1.1)
     byebug (11.1.3)
     diff-lcs (1.5.0)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    net-http (0.4.1)
+      uri
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -44,12 +50,14 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     unicode-display_width (2.4.2)
+    uri (0.13.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug (~> 11.1)
+  faraday (~> 2.9)
   rspec (~> 3.12)
   rubocop (~> 1.56)
 

--- a/curlify.gemspec
+++ b/curlify.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'curlify'
-  s.version     = '1.0.1'
+  s.version     = '1.0.2'
   s.summary     = 'Hola!'
   s.description = 'The gem convert python requests object in curl command.'
   s.authors     = ['Marcus Almeida']
@@ -19,5 +19,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.md LICENSE]
 
-  s.required_ruby_version = '>= 3.2.0'
+  s.required_ruby_version = '>= 2.7.8'
+
+  s.add_dependency 'faraday', '>= 2.0'
 end

--- a/lib/curlify.rb
+++ b/lib/curlify.rb
@@ -12,8 +12,8 @@ class Curlify
   end
 
   def to_curl
-    return curl_request << ' --compressed' if compressed
-    return curl_request << ' --insecure' unless verify
+    return "#{curl_request} --compressed" if compressed
+    return "#{curl_request} --insecure" unless verify
 
     curl_request
   end
@@ -21,16 +21,18 @@ class Curlify
   private
 
   def curl_request
-    "curl -X #{method.upcase} #{headers} #{body} #{url}"
+    "curl -X #{http_method.upcase} #{headers} #{body} #{url}"
   end
 
   def headers
-    return context_headers(request.headers) if request.is_a?(Faraday::Request)
-
-    context_headers(request.each_header)
+    if request.is_a?(Faraday::Request)
+      context_headers(request.headers)
+    else
+      context_headers(request.each_header)
+    end
   end
 
-  def method
+  def http_method
     request.is_a?(Faraday::Request) ? request.http_method : request.method
   end
 

--- a/spec/curlify_spec.rb
+++ b/spec/curlify_spec.rb
@@ -1,15 +1,17 @@
 require 'json'
 require 'uri'
 require 'net/http'
+require 'faraday'
 
 require './lib/curlify'
 
 describe Curlify do
   let(:context) { described_class.new(request) }
-  let(:uri) { URI('http://127.0.0.1') }
+  let(:uri)     { URI('http://127.0.0.1') }
+  let(:headers) { { 'content-type': 'application/json' } }
   let(:response) do
     <<~CURL
-      curl -X #{request.method} \
+      curl -X #{method} \
       -H 'content-type: application/json' \
       -H 'accept-encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3' \
       -H 'accept: */*' \
@@ -25,6 +27,7 @@ describe Curlify do
       let(:request) { Net::HTTP::Get.new(uri, { 'content-type': 'application/json' }) }
       let(:body)    { nil }
       let(:payload) { nil }
+      let(:method)  { request.method }
 
       it { expect(context.to_curl).to eq response.strip }
     end
@@ -33,6 +36,7 @@ describe Curlify do
       let(:request) { Net::HTTP::Post.new(uri, { 'content-type': 'application/json' }) }
       let(:payload) { { name: 'John' }.to_json }
       let(:body)    { "-d '#{payload}'" }
+      let(:method)  { request.method }
 
       it { expect(context.to_curl).to eq response.strip }
     end
@@ -41,6 +45,7 @@ describe Curlify do
       let(:request)  { Net::HTTP::Put.new(uri, { 'content-type': 'application/json' }) }
       let(:payload)  { { name: 'John', userId: 1 }.to_json }
       let(:body)     { "-d '#{payload}'" }
+      let(:method) { request.method }
 
       before { request.body = payload }
 
@@ -51,8 +56,39 @@ describe Curlify do
       let(:request) { Net::HTTP::Delete.new(uri, { 'content-type': 'application/json' }) }
       let(:body)    { "-d '#{payload}'" }
       let(:payload) { { userId: 1 }.to_json }
+      let(:method)  { request.method }
 
       before { request.body = payload }
+
+      it { expect(context.to_curl).to eq response.strip }
+    end
+
+    context 'when the curl command is gernerated with Faraday' do
+      let(:payload)  { nil }
+      let(:response) { "curl -X GET -H 'Content-type: application/json'  http://127.0.0.1" }
+      let(:method)   { request.http_method }
+      let(:request) do
+        Faraday.new.build_request(:get) do |req|
+          req.url 'http://127.0.0.1'
+          req.headers = headers
+        end
+      end
+
+      it { expect(context.to_curl).to eq response.strip }
+    end
+
+    context 'when the curl command is gernerated with Faraday' do
+      let(:body)     { "-d '#{payload}'" }
+      let(:payload)  { { userId: 1 }.to_json }
+      let(:method)   { request.http_method }
+      let(:response) { "curl -X POST -H 'Content-type: application/json' -d '{\"userId\":1}' http://127.0.0.1" }
+
+      let(:request) do
+        Faraday.new.build_request(:post) do |req|
+          req.url 'http://127.0.0.1'
+          req.headers = headers
+        end
+      end
 
       it { expect(context.to_curl).to eq response.strip }
     end


### PR DESCRIPTION
Now, this gem supports the Faraday `gem`. Eg:

```ruby
request = Faraday.new.build_request(:post) do |req|
  req.url 'http://127.0.0.1'
  req.headers = headers
end

curlify = Curlify.new(request)

puts curlify

curl -X POST -H 'Content-type: application/json' -d '{\"userId\":1}' http://127.0.0.1
```

Close #5 