### PR TITLE
feat: add clipboard support to Curlify for copying curl commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ request.body = { title: 'Ruby is great :)' }.to_json
 Curlify.new(request).to_curl # curl -X POST -H 'content-type: application/json' -H 'accept-encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3' -H 'accept: */*' -H 'user-agent: Ruby' -H 'host: httpbin.org' -d '{"title":"Ruby is great :)"}' https://httpbin.org/post
 ```
 
+## Clipboard support
+
+Curlify can copy the generated curl command directly to the operating system clipboard. To enable this behavior, pass `clipboard: true` when creating the `Curlify` instance. The method still returns the curl string.
+
+Supported platforms:
+- macOS: uses `pbcopy`
+- Windows: uses `clip`
+- Linux: uses `xclip` (must be installed and available in `PATH`)
+
+Example:
+
+```ruby
+# copy to clipboard and return the curl string
+Curlify.new(request, clipboard: true).to_curl
+```
+
+If `xclip` is not available on Linux, Curlify will print a warning: `Curlify Warning: 'xclip' is required for clipboard support on Linux.`
+
+
 Performing this curl command, we can see the following result:
 
 ```bash

--- a/curlify.gemspec
+++ b/curlify.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name        = 'curlify'
-  s.version     = '1.1.0'
-  s.summary     = 'Hola!'
-  s.description = 'The gem convert python requests object in curl command.'
+  s.version     = '1.2.0'
+  s.summary     = 'Convert Ruby HTTP request objects into curl commands'
+  s.description = 'Convert Ruby HTTP request and client objects into their equivalent curl command. Useful for debugging and sharing HTTP requests.'
   s.authors     = ['Marcus Almeida']
   s.email       = 'mpereirassa@gmail.com'
   s.files       = ['lib/curlify.rb']

--- a/lib/curlify.rb
+++ b/lib/curlify.rb
@@ -14,18 +14,23 @@ class Curlify
   end
 
   def to_curl
-    string = curl_request
-    string += '--insecure ' unless verify
-    string += '--compressed' if compressed
-
-    copy_to_clipboard(string)
-    string
+    command = build_curl_command
+    copy_to_clipboard(command)
+    command
   end
 
   private
 
+  def build_curl_command
+    [
+      curl_request,
+      verify ? nil : '--insecure',
+      compressed ? '--compressed' : nil
+    ].compact.join(' ')
+  end
+
   def curl_request
-    "curl -X #{http_method.upcase} #{headers} #{body} #{url} "
+    "curl -X #{http_method.upcase} #{headers} #{body} #{url}".strip
   end
 
   def headers

--- a/lib/curlify.rb
+++ b/lib/curlify.rb
@@ -1,27 +1,31 @@
 # frozen_string_literal: true
 
 require 'faraday'
+require 'byebug'
 
 class Curlify
-  attr_reader :request, :verify, :compressed
+  attr_reader :request, :verify, :compressed, :clipboard
 
-  def initialize(request, compressed: false, verify: true)
+  def initialize(request, compressed: false, verify: true, clipboard: false)
     @request = request
     @compressed = compressed
     @verify = verify
+    @clipboard = clipboard
   end
 
   def to_curl
-    return "#{curl_request} --compressed" if compressed
-    return "#{curl_request} --insecure" unless verify
+    string = curl_request
+    string += '--insecure ' unless verify
+    string += '--compressed' if compressed
 
-    curl_request
+    copy_to_clipboard(string)
+    string
   end
 
   private
 
   def curl_request
-    "curl -X #{http_method.upcase} #{headers} #{body} #{url}"
+    "curl -X #{http_method.upcase} #{headers} #{body} #{url} "
   end
 
   def headers
@@ -46,5 +50,25 @@ class Curlify
 
   def context_headers(headers)
     headers.map { |k, v| "-H '#{k}: #{v}'" }.join(' ')
+  end
+
+  def copy_to_clipboard(string)
+    return unless clipboard
+
+    command = clipboard_command
+    return warn("Curlify Warning: 'xclip' is required for clipboard support on Linux.") unless command
+
+    IO.popen(command, 'w') { |f| f << string }
+  end
+
+  def clipboard_command
+    case RUBY_PLATFORM
+    when /darwin/
+      'pbcopy'
+    when /mswin|mingw|cygwin/
+      'clip'
+    when /linux/
+      'xclip -selection clipboard' if system('which xclip > /dev/null 2>&1')
+    end
   end
 end


### PR DESCRIPTION
Now it's possible to copy the output curl command to the clipboard automatically 

1. Check the video:

[![asciicast](https://asciinema.org/a/757164.svg)](https://asciinema.org/a/757164)