### PR TITLE
feat: add Settings class for YAML configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 The gem converts ruby requests to curl
 
+## Features
+
+- **Multi-Framework Support**: Works with Faraday and Net::HTTP requests
+- **Clipboard Integration**: Copy generated curl commands directly to clipboard (macOS, Windows, Linux)
+- **Configuration Management**: YAML-based settings for customizing Curlify behavior
+- **Simple API**: Easy-to-use interface with minimal configuration required
+
 ## Installation
 
 To install the gem use `bundle` or `gem`, see:
@@ -55,15 +62,121 @@ Supported platforms:
 - Windows: uses `clip`
 - Linux: uses `xclip` (must be installed and available in `PATH`)
 
-Example:
-
-```ruby
-# copy to clipboard and return the curl string
-Curlify.new(request, clipboard: true).to_curl
-```
-
 If `xclip` is not available on Linux, Curlify will print a warning: `Curlify Warning: 'xclip' is required for clipboard support on Linux.`
 
+## Configuration
+
+Curlify supports configuration management through a YAML settings file. You can customize the default behavior by creating a `settings.yml` configuration file in your `config` directory.
+
+### Creating Your Configuration File
+
+#### Step 1: Create the config directory (if it doesn't exist)
+
+```bash
+mkdir -p config
+```
+
+#### Step 2: Create the settings.yml file
+
+Create a file named `settings.yml` in the `config` directory:
+
+```bash
+touch config/settings.yml
+```
+
+#### Step 3: Configure your settings
+
+Open `config/settings.yml` and add your Curlify configuration options:
+
+```yaml
+# config/settings.yml
+clipboard: false
+verify: true
+compressed: false
+```
+
+### Available Configuration Options
+
+- **clipboard** (boolean, default: `false`): Automatically copy generated curl commands to the clipboard
+  - `true`: Copy curl command to clipboard
+  - `false`: Only return the curl string
+
+- **verify** (boolean, default: `true`): Verify SSL certificates when making requests
+  - `true`: Verify SSL certificates
+  - `false`: Skip SSL verification (use with caution)
+
+- **compressed** (boolean, default: `false`): Add compression support to curl commands
+  - `true`: Add `--compressed` flag to curl command
+  - `false`: No compression flag
+
+### Usage Examples
+
+#### Example 1: Basic Configuration
+
+```yaml
+# config/settings.yml
+clipboard: false
+verify: true
+compressed: false
+```
+
+Then use Curlify normally:
+
+```ruby
+require 'faraday'
+require 'curlify'
+
+request = Faraday.new.build_request(:post) do |req|
+  req.url 'http://127.0.0.1'
+end
+
+# Uses settings from config/settings.yml
+Curlify.new(request).to_curl
+```
+
+#### Example 2: Enable Clipboard Support
+
+```yaml
+# config/settings.yml
+clipboard: true
+verify: true
+compressed: false
+```
+
+Now every curl command will be automatically copied to your clipboard:
+
+```ruby
+require 'faraday'
+require 'curlify'
+
+request = Faraday.new.build_request(:get) do |req|
+  req.url 'https://api.example.com/data'
+end
+
+curl_command = Curlify.new(request).to_curl
+# curl_command is now in your clipboard!
+puts curl_command
+```
+
+#### Example 3: Production Configuration
+
+```yaml
+# config/settings.yml
+clipboard: false
+verify: true
+compressed: true
+```
+
+This configuration is suitable for production environments where you want:
+- No automatic clipboard operations
+- SSL verification enabled for security
+- Compressed curl commands
+
+### Troubleshooting
+
+- **Configuration file not found**: Make sure the `config/settings.yml` file exists in your project root directory
+- **Settings not loading**: Verify the YAML syntax is correct (indentation matters in YAML)
+- **Clipboard not working on Linux**: Ensure `xclip` is installed: `sudo apt-get install xclip`
 
 Performing this curl command, we can see the following result:
 

--- a/curlify.gemspec
+++ b/curlify.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s|
   s.name        = 'curlify'
-  s.version     = '1.2.0'
+  s.version     = '2.0.0'
   s.summary     = 'Convert Ruby HTTP request objects into curl commands'
   s.description = 'Convert Ruby HTTP request and client objects into their equivalent curl command. Useful for debugging and sharing HTTP requests.'
   s.authors     = ['Marcus Almeida']
   s.email       = 'mpereirassa@gmail.com'
-  s.files       = ['lib/curlify.rb']
+  s.files       = ['lib/curlify.rb', 'lib/settings.rb']
   s.homepage    =
     'https://rubygems.org/gems/curlify'
   s.license = 'MIT'

--- a/lib/curlify.rb
+++ b/lib/curlify.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'byebug'
+
+require_relative 'settings'
 
 class Curlify
-  attr_reader :request, :verify, :compressed, :clipboard
+  attr_reader :request
 
-  def initialize(request, compressed: false, verify: true, clipboard: false)
+  def initialize(request)
     @request = request
-    @compressed = compressed
-    @verify = verify
-    @clipboard = clipboard
+
+    Settings.call.each do |key, value|
+      instance_variable_set("@#{key}", value)
+      define_singleton_method(key) { instance_variable_get("@#{key}") }
+    end
   end
 
   def to_curl

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -8,6 +8,17 @@ class Settings
   private
 
   def params
-    YAML.load_file(File.join('config', 'settings.yml'))
+    YAML.safe_load(
+      read_file,
+      permitted_classes: [],
+      permitted_symbols: [],
+      aliases: true
+    )
+  end
+
+  def read_file
+    File.read(
+      File.join('config', 'settings.yml')
+    )
   end
 end

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -1,0 +1,13 @@
+require 'yaml'
+
+class Settings
+  def self.call
+    new.send(:params)
+  end
+
+  private
+
+  def params
+    YAML.load_file(File.join('config', 'settings.yml'))
+  end
+end

--- a/spec/curlify_spec.rb
+++ b/spec/curlify_spec.rb
@@ -4,6 +4,7 @@ require 'net/http'
 require 'faraday'
 
 require './lib/curlify'
+require './lib/settings'
 
 describe Curlify do
   let(:context) { described_class.new(request) }
@@ -20,8 +21,17 @@ describe Curlify do
     CURL
   end
 
+  before do
+    allow(Settings).to receive(:call).and_return(
+      {
+        clipboard: false,
+        verify: true,
+        compressed: false
+      }
+    )
+  end
+
   describe 'must transform request into curl command' do
-    before { request.body = payload }
     context 'when is a GET request' do
       let(:request) { Net::HTTP::Get.new(uri, { 'content-type': 'application/json' }) }
       let(:body)    { nil }
@@ -36,6 +46,8 @@ describe Curlify do
       let(:payload) { { name: 'John' }.to_json }
       let(:body)    { "-d '#{payload}'" }
       let(:method)  { request.method }
+
+      before { request.body = payload }
 
       it { expect(context.to_curl).to eq response.strip }
     end
@@ -86,6 +98,7 @@ describe Curlify do
         Faraday.new.build_request(:post) do |req|
           req.url 'http://127.0.0.1'
           req.headers = headers
+          req.body = payload
         end
       end
 
@@ -99,8 +112,8 @@ describe Curlify do
 
     before { request.body = payload }
 
-    context 'when clipboard is disabled' do
-      let(:context) { described_class.new(request, clipboard: false) }
+    context 'when clipboard is disabled by default' do
+      let(:context) { described_class.new(request) }
 
       it 'does not copy to clipboard' do
         expect(IO).not_to receive(:popen)
@@ -109,7 +122,18 @@ describe Curlify do
     end
 
     context 'when clipboard is enabled' do
-      let(:context) { described_class.new(request, clipboard: true) }
+      let(:context) { described_class.new(request) }
+      let(:expected_params) do
+        {
+          clipboard: true,
+          verify: false,
+          compressed: false
+        }
+      end
+
+      before do
+        allow(Settings).to receive(:call).and_return(expected_params)
+      end
 
       context 'on macOS' do
         before { stub_const('RUBY_PLATFORM', 'darwin') }
@@ -164,11 +188,19 @@ describe Curlify do
 
   describe '#build_curl_command' do
     let(:request) { Net::HTTP::Get.new(uri, headers) }
-    let(:context) { described_class.new(request, compressed: compressed, verify: verify) }
+    let(:context) { described_class.new(request) }
+    let(:expected_params) do
+      {
+        clipboard: false,
+        verify: true,
+        compressed: false
+      }
+    end
 
     context 'when verify is true and compressed is false' do
-      let(:verify) { true }
-      let(:compressed) { false }
+      before do
+        allow(Settings).to receive(:call).and_return(expected_params)
+      end
 
       it 'does not include --insecure or --compressed' do
         result = context.to_curl
@@ -177,9 +209,18 @@ describe Curlify do
       end
     end
 
-    context 'when verify is false' do
-      let(:verify) { false }
-      let(:compressed) { false }
+    context 'when verify and compressed are falsely' do
+      let(:expected_params) do
+        {
+          clipboard: false,
+          verify: false,
+          compressed: false
+        }
+      end
+
+      before do
+        allow(Settings).to receive(:call).and_return(expected_params)
+      end
 
       it 'includes --insecure flag' do
         result = context.to_curl
@@ -188,8 +229,18 @@ describe Curlify do
     end
 
     context 'when compressed is true' do
-      let(:verify) { true }
-      let(:compressed) { true }
+      let(:context) { described_class.new(request) }
+      let(:expected_params) do
+        {
+          clipboard: false,
+          verify: true,
+          compressed: true
+        }
+      end
+
+      before do
+        allow(Settings).to receive(:call).and_return(expected_params)
+      end
 
       it 'includes --compressed flag' do
         result = context.to_curl
@@ -198,8 +249,17 @@ describe Curlify do
     end
 
     context 'when both verify is false and compressed is true' do
-      let(:verify) { false }
-      let(:compressed) { true }
+      let(:expected_params) do
+        {
+          clipboard: false,
+          verify: false,
+          compressed: true
+        }
+      end
+
+      before do
+        allow(Settings).to receive(:call).and_return(expected_params)
+      end
 
       it 'includes both --insecure and --compressed flags' do
         result = context.to_curl

--- a/spec/curlify_spec.rb
+++ b/spec/curlify_spec.rb
@@ -209,7 +209,7 @@ describe Curlify do
       end
     end
 
-    context 'when verify and compressed are falsely' do
+    context 'when verify and compressed are falsey' do
       let(:expected_params) do
         {
           clipboard: false,

--- a/spec/lib/settings_spec.rb
+++ b/spec/lib/settings_spec.rb
@@ -1,0 +1,31 @@
+require './lib/settings'
+
+RSpec.describe '.call' do
+  context 'when settings file exists' do
+    let(:expected_settings) do
+      {
+        'compressed' => false,
+        'verify' => true,
+        'clipboard' => false
+      }
+    end
+
+    before do
+      allow_any_instance_of(Settings).to receive(:params).and_return(expected_settings)
+    end
+
+    it 'returns parsed settings as symbols' do
+      expect(Settings.call).to eq(expected_settings)
+    end
+  end
+
+  context 'when settings file does not exist' do
+    before do
+      allow_any_instance_of(Settings).to receive(:params).and_raise(Errno::ENOENT)
+    end
+
+    it 'raises Errno::ENOENT' do
+      expect { Settings.call }.to raise_error(Errno::ENOENT)
+    end
+  end
+end

--- a/spec/lib/settings_spec.rb
+++ b/spec/lib/settings_spec.rb
@@ -1,6 +1,6 @@
 require './lib/settings'
 
-RSpec.describe '.call' do
+RSpec.describe Settings do
   context 'when settings file exists' do
     let(:expected_settings) do
       {


### PR DESCRIPTION
🎯 **<ins>Gaols</ins>**
The goal of this `pull request` is to separate configurations from `Curlify` class. Creating a settings.yaml file in `~/config/` 